### PR TITLE
Implemented Streaming Functionality(Kafka)

### DIFF
--- a/AdminService/pom.xml
+++ b/AdminService/pom.xml
@@ -50,7 +50,15 @@
 			<artifactId>aws-java-sdk-s3</artifactId>
 			<version>1.12.543</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 	<dependencyManagement>

--- a/AdminService/src/main/java/com/project/AdminService/Configs/KafkaConfig.java
+++ b/AdminService/src/main/java/com/project/AdminService/Configs/KafkaConfig.java
@@ -1,0 +1,14 @@
+package com.project.AdminService.Configs;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+    @Bean
+    public NewTopic newTopic(){
+        return TopicBuilder.name("Video-Stream").build();
+    }
+}

--- a/AdminService/src/main/java/com/project/AdminService/Controllers/AdminController.java
+++ b/AdminService/src/main/java/com/project/AdminService/Controllers/AdminController.java
@@ -1,22 +1,37 @@
 package com.project.AdminService.Controllers;
 
 import com.project.AdminService.Services.AdminService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import javax.servlet.http.HttpServletResponse;
 
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
 @RestController
+@Data
+@AllArgsConstructor
+@Log4j2
 @RequestMapping("/streamKaro")
 public class AdminController {
 
     @Autowired
     private AdminService adminService;
+
+    private final KafkaTemplate<String, byte[]> kafkaTemplate;
 
     @PostMapping("/upload")
     public ResponseEntity<String> uploadFile(@RequestParam(value = "file") MultipartFile file) {
@@ -51,4 +66,29 @@ public class AdminController {
 
         return ResponseEntity.ok(videoList); // Return the list of video filenames or metadata
     }
+
+    @GetMapping(value = "/stream/{fileName}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public void streamVideo(@PathVariable String fileName, HttpServletResponse response) throws IOException {
+        InputStream videoStream = adminService.getVideoChunkStream(fileName);
+
+        // Set the content type to video/mp4 or appropriate video format
+        response.setContentType("video/mp4");
+
+        // Create an output stream to write the video data to the response
+        OutputStream outputStream = response.getOutputStream();
+
+        byte[] buffer = new byte[1024];
+        int bytesRead;
+        while ((bytesRead = videoStream.read(buffer)) != -1) {
+            outputStream.write(buffer, 0, bytesRead);
+
+            // Send the video data to Kafka in real-time
+            log.info("sending now..");
+            kafkaTemplate.send("Video-Stream", buffer);
+        }
+
+        outputStream.flush();
+        outputStream.close();
+    }
+
 }

--- a/AdminService/src/main/java/com/project/AdminService/Services/AdminService.java
+++ b/AdminService/src/main/java/com/project/AdminService/Services/AdminService.java
@@ -2,6 +2,7 @@ package com.project.AdminService.Services;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -14,4 +15,6 @@ public interface AdminService {
     String deleteFile(String fileName);
 
     List<Map<String,String>> listVideos();
+
+    InputStream getVideoChunkStream(String fileName);
 }

--- a/AdminService/src/main/java/com/project/AdminService/Services/AdminServiceIMPL.java
+++ b/AdminService/src/main/java/com/project/AdminService/Services/AdminServiceIMPL.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +69,18 @@ public class AdminServiceIMPL implements AdminService{
                     );
                     return videoInfo;}).collect(Collectors.toList());
     }
+
+    @Override
+    public InputStream getVideoChunkStream(String fileName) {
+        // Fetch the S3 object
+        S3Object s3Object = client.getObject(bucket, fileName);
+
+        // Get the input stream of the S3 object
+        S3ObjectInputStream inputStream = s3Object.getObjectContent();
+
+        return inputStream;
+    }
+
     private File convertMultiPartFileToFile(MultipartFile file) {
         File convertedFile = new File(file.getOriginalFilename());
         try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
@@ -77,5 +90,7 @@ public class AdminServiceIMPL implements AdminService{
         }
         return convertedFile;
     }
+
+
 }
 

--- a/AdminService/src/main/resources/application.yaml
+++ b/AdminService/src/main/resources/application.yaml
@@ -12,20 +12,14 @@ spring:
       file-size-threshold: 800MB
       max-file-size: 1GB
       max-request-size: 1GB
-
-
-cloud:
-  aws:
-    credentials:
-      access-key:
-      secret-key:
-    region:
-      static: eu-north-1
-    stack:
-      auto: false
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArraySerializer
 
 application:
   bucket:
-    name:
+    name: streamingvideos
 
 

--- a/FrontendService/pom.xml
+++ b/FrontendService/pom.xml
@@ -50,6 +50,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/FrontendService/src/main/java/com/project/FrontendService/Configs/KafkaConfig.java
+++ b/FrontendService/src/main/java/com/project/FrontendService/Configs/KafkaConfig.java
@@ -1,0 +1,30 @@
+package com.project.FrontendService.Configs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.KafkaListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@Data
+@Log4j2
+public class KafkaConfig {
+
+    private final List<byte[]> videoPackets = new ArrayList<>();
+    @KafkaListener(topics = "Video-Stream", groupId = "stream-group")
+    public void receiveStream(byte[] packet) {
+        log.info("receiving now..");
+        // Adding Packets To List
+        videoPackets.add(packet);
+    }
+
+    // Method to retrieve the video packets for streaming
+    public List<byte[]> getVideoPackets() {
+        return videoPackets;
+    }
+}

--- a/FrontendService/src/main/java/com/project/FrontendService/Controllers/FrontendControllers.java
+++ b/FrontendService/src/main/java/com/project/FrontendService/Controllers/FrontendControllers.java
@@ -1,12 +1,25 @@
 package com.project.FrontendService.Controllers;
 
+import com.project.FrontendService.Configs.KafkaConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 @Controller
 @RequestMapping("/streamKaro/admin")
 public class FrontendControllers {
+
+    @Autowired
+    private KafkaConfig kafkaConfig;
 
     @GetMapping
     public String index(){
@@ -17,5 +30,21 @@ public class FrontendControllers {
     public String videoUpload(){
         return "videoManager";
     }
+
+//    @GetMapping("/stream")
+//    public ResponseEntity<StreamingResponseBody> streamVideo(HttpServletResponse response) {
+//        List<byte[]> videoPackets = kafkaConfig.getVideoPackets();
+//
+//        StreamingResponseBody streamingResponseBody = outputStream -> {
+//            for (byte[] packet : videoPackets) {
+//                outputStream.write(packet);
+//                outputStream.flush();
+//            }
+//        };
+//
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+//        return new ResponseEntity<>(streamingResponseBody, headers, HttpStatus.OK);
+//    }
 
 }

--- a/FrontendService/src/main/resources/application.yaml
+++ b/FrontendService/src/main/resources/application.yaml
@@ -6,5 +6,11 @@ spring:
     name: FRONTEND-SERVICE
   config:
     import: configserver:http://localhost:9296
-
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:9092
+      group-id: stream-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
 


### PR DESCRIPTION
 Implemented HTTP endpoint for streaming video packets and Kafka publishing:

1. **HTTP Endpoint**: I've introduced a new HTTP endpoint API within the AdminService. This endpoint is designed to facilitate the streaming of video packets. Users can now request video content, and the adminservice will send video packets to the client one at a time, ensuring efficient and smooth streaming.

2. **Kafka Integration**: Alongside the HTTP endpoint, I've integrated Kafka functionality into the adminservice. Now, whenever a video stream is initiated, the adminservice acts as a Kafka producer. It publishes video information events onto a Kafka topic. This information could include metadata about the video, such as its title, duration, and other relevant details.

3. **Frontend Communication**: The Kafka events produced by the AdminService are designed to be consumed by the frontend service. This means that as video streams are requested and initiated, the frontend service will be able to hear and react to these events. This sets the foundation for building a responsive and interactive user interface that can display video information and handle streaming playback.

While this commit represents significant progress, please note that the user interface and additional functionality on the frontend are still in development. The next steps involve implementing the user interface components and enhancing the overall user experience.

